### PR TITLE
Add column to "repository" for caching.

### DIFF
--- a/src/main/resources/db/changelog-master.yml
+++ b/src/main/resources/db/changelog-master.yml
@@ -14,3 +14,6 @@ databaseChangeLog:
 
 - include:
     file: db/changes/v1.9-schema.yml
+
+- include:
+    file: db/changes/v1.9-caching.yml

--- a/src/main/resources/db/changes/v1.9-caching.yml
+++ b/src/main/resources/db/changes/v1.9-caching.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: v1.9-caching
+      author: wgrim
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  defaultValueBoolean: false
+                  name: cachingEnabled
+                  type: boolean
+            tableName: repository
+        - addColumn:
+            columns:
+              - column:
+                  name: cachingEnabled
+                  type: boolean
+            tableName: repository_audit


### PR DESCRIPTION
When the variable is true, ConfigHub should
cache a repository's properties for given
contexts lazily and evict them from the
cache when the repository is updated.