### PR TITLE
Fix old type change that was incorrect.

### DIFF
--- a/src/main/resources/db/changes/v1.8-type-changes.yml
+++ b/src/main/resources/db/changes/v1.8-type-changes.yml
@@ -48,7 +48,7 @@ databaseChangeLog:
         tableName: repofile
     - modifyDataType:
         columnName: content
-        newDataType: TEXT
+        newDataType: MEDIUMTEXT
         tableName: repofile
 
 - changeSet:
@@ -65,7 +65,7 @@ databaseChangeLog:
         tableName: repofile_audit
     - modifyDataType:
         columnName: content
-        newDataType: TEXT
+        newDataType: MEDIUMTEXT
         tableName: repofile_audit
 
 - changeSet:

--- a/src/main/resources/db/changes/v1.9-type-changes.yml
+++ b/src/main/resources/db/changes/v1.9-type-changes.yml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+
+- changeSet:
+    id: v1.9-type-changes-1
+    author: wgrim
+    preConditions:
+    - onFail: MARK_RAN
+    - tableExists:
+        tableName: repofile
+    changes:
+    - modifyDataType:
+        columnName: content
+        newDataType: MEDIUMTEXT
+        tableName: repofile
+
+- changeSet:
+    id: v1.9-type-changes-2
+    author: wgrim
+    preConditions:
+    - onFail: MARK_RAN
+    - tableExists:
+        tableName: repofile_audit
+    changes:
+    - modifyDataType:
+        columnName: content
+        newDataType: MEDIUMTEXT
+        tableName: repofile_audit


### PR DESCRIPTION
Old repofile.content change from LONGTEXT to TEXT was too
restrictive, resulting in failures in testing when existing
seed data was too large.  MEDIUMTEXT is more reasonable
then LONGTEXT while still allowing quite large sizes.

This change has been applied twice so that users out
there that had applied the older change can stay in-sync.